### PR TITLE
Rename DappConnect to Waku Connect & Fix some links

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -28,7 +28,7 @@
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/node">Try</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/blog">Blog</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Support</a></li>
-        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Specs</a></li>
+        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
       </ul>
     </nav>
     <div id="social-box" class="hidden md:flex">
@@ -185,7 +185,7 @@
         <ul class="grid grid-cols-1 text-white70 md:grid-cols-2 md:gap-x-6">
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/about">About</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">FAQ</a></li>
-          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">Specs</a></li>
+          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/node">Run a node</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/blog">Blog</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://forum.vac.dev/">Forum</a></li>

--- a/src/blog.html
+++ b/src/blog.html
@@ -25,7 +25,7 @@
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/node">Try</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium font-bold text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/blog">Blog</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Support</a></li>
-        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Specs</a></li>
+        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
       </ul>
     </nav>
     <div id="social-box" class="hidden md:flex">
@@ -176,7 +176,7 @@
         <ul class="grid grid-cols-1 text-white70 md:grid-cols-2 md:gap-x-6">
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/about">About</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">FAQ</a></li>
-          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">Specs</a></li>
+          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/node">Run a node</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/blog">Blog</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://forum.vac.dev/">Forum</a></li>

--- a/src/index.html
+++ b/src/index.html
@@ -117,10 +117,10 @@
 						</div>
 						<div class="grid grid-cols-1 gap-6 md:grid-cols-3 lg:w-8/12 lg:gap-9">
 							<div>
-								<h3 class="font-semibold text-lg leading-10 mb-2">DApp Connect</h3>
+								<h3 class="font-semibold text-lg leading-10 mb-2">Waku Connect</h3>
 								<div>
 									<p class="text-sm leading-6">The communication layer for Ethereum. A tech stack enabling decentralized communication between DApps and people.</p>
-									<a class="inline-block text-sm text-blue underline italic pl-3 mt-6 bg-link-arrow-blue bg-left bg-no-repeat lg:no-underline hover:underline" href="">Visit DApp Connect</a>
+									<a class="inline-block text-sm text-blue underline italic pl-3 mt-6 bg-link-arrow-blue bg-left bg-no-repeat lg:no-underline hover:underline" href="">Visit Waku Connect</a>
 								</div>
 							</div>
 							<div>

--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,7 @@
 						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/node">Try</a></li>
 						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/blog">Blog</a></li>
 						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Support</a></li>
-						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Specs</a></li>
+						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
 					</ul>
 				</nav>
 				<div id="social-box" class="hidden md:flex">
@@ -366,7 +366,7 @@
 					<ul class="grid grid-cols-1 text-white70 md:grid-cols-2 md:gap-x-6">
 						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/about">About</a></li>
 						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">FAQ</a></li>
-						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">Specs</a></li>
+						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
 						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/node">Run a node</a></li>
 						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/blog">Blog</a></li>
 						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://forum.vac.dev/">Forum</a></li>

--- a/src/index.html
+++ b/src/index.html
@@ -127,7 +127,7 @@
 								<h3 class="font-semibold text-lg leading-10 mb-2">Status</h3>
 								<div>
 									<p class="text-sm leading-6">Status is a secure messaging app, crypto wallet, and Web3 browser built with state of the art technology.</p>
-									<a class="inline-block text-sm text-blue underline italic pl-3 mt-6 bg-link-arrow-blue bg-left bg-no-repeat lg:no-underline hover:underline" href="">Visit Status</a>
+									<a class="inline-block text-sm text-blue underline italic pl-3 mt-6 bg-link-arrow-blue bg-left bg-no-repeat lg:no-underline hover:underline" href="https://status.im/">Visit Status</a>
 								</div>
 							</div>
 							<div>

--- a/src/index.html
+++ b/src/index.html
@@ -120,7 +120,7 @@
 								<h3 class="font-semibold text-lg leading-10 mb-2">Waku Connect</h3>
 								<div>
 									<p class="text-sm leading-6">The communication layer for Ethereum. A tech stack enabling decentralized communication between DApps and people.</p>
-									<a class="inline-block text-sm text-blue underline italic pl-3 mt-6 bg-link-arrow-blue bg-left bg-no-repeat lg:no-underline hover:underline" href="">Visit Waku Connect</a>
+									<a class="inline-block text-sm text-blue underline italic pl-3 mt-6 bg-link-arrow-blue bg-left bg-no-repeat lg:no-underline hover:underline" href="https://wakuconnect.dev">Visit Waku Connect</a>
 								</div>
 							</div>
 							<div>

--- a/src/node.html
+++ b/src/node.html
@@ -28,7 +28,7 @@
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium font-bold text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/node">Try</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/blog">Blog</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Support</a></li>
-        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Specs</a></li>
+        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
       </ul>
     </nav>
     <div id="social-box" class="hidden md:flex">
@@ -275,7 +275,7 @@
         <ul class="grid grid-cols-1 text-white70 md:grid-cols-2 md:gap-x-6">
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/about">About</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">FAQ</a></li>
-          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">Specs</a></li>
+          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/node">Run a node</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/blog">Blog</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://forum.vac.dev/">Forum</a></li>


### PR DESCRIPTION
Wasn't sure if we want the `Specs` link to point to Waku v2 spec ttps://rfc.vac.dev/spec/10/ or just ttps://rfc.vac.dev/