### PR TITLE
Update links

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -13,7 +13,7 @@
 
 <header class="fixed inset-x-0 z-50 bg-white">
   <div class="h-18 max-w-screen-xl flex justify-between items-center mx-auto px-6 py-4  md:h-26 md:py-8 xl:px-0">
-    <a id="header-logo" class="text-gray" href="/index">
+    <a id="header-logo" class="text-gray" href="/">
       <img src="assets/images/logo/logo.svg" alt="">
     </a>
     <nav id="nav" class="absolute flex items-center justify-end -z-1 top-0 left-0 h-screen w-full bg-gray pt-16 pr-16 transform -translate-y-full md:-translate-y-0 md:bg-white md:relative md:h-auto md:p-0 md:justify-center md:z-0">
@@ -23,22 +23,22 @@
         </svg>
       </div>
       <ul class="text-right text-white md:flex md:text-gray md:text-center">
-        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/index">Home</a></li>
+        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/">Home</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium font-bold text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/about">About</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/node">Try</a></li>
-        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/blog">Blog</a></li>
+        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://vac.dev/research-log/">Blog</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Support</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
       </ul>
     </nav>
     <div id="social-box" class="hidden md:flex">
-      <a class="text-gray mr-6 hover:text-blue" href="">
+      <a class="text-gray mr-6 hover:text-blue" href="https://discord.gg/ev9GQGJ9Dg">
         <img src="./assets/images/social/discord-dark.svg" alt="discord">
       </a>
-      <a class="text-gray mr-6 hover:text-blue" href="">
+      <a class="text-gray mr-6 hover:text-blue" href="https://twitter.com/vacp2p">
         <img src="./assets/images/social/twitter-dark.svg" alt="twitter">
       </a>
-      <a class="text-gray hover:text-blue" href="">
+      <a class="text-gray hover:text-blue" href="https://github.com/vacp2p/">
         <img src="./assets/images/social/github-dark.svg" alt="github">
       </a>
     </div>
@@ -187,7 +187,7 @@
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">FAQ</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/node">Run a node</a></li>
-          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/blog">Blog</a></li>
+          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://vac.dev/research-log/">Blog</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://forum.vac.dev/">Forum</a></li>
           <li><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://jobs.status.im/">Careers</a></li>
         </ul>

--- a/src/blog.html
+++ b/src/blog.html
@@ -12,7 +12,7 @@
 <body class="font-body overflow-x-hidden">
 <header class="fixed inset-x-0 z-50 bg-white">
   <div class="h-18 max-w-screen-xl flex justify-between items-center mx-auto px-6 py-4 md:h-26 md:py-8 xl:px-0">
-    <a id="header-logo" class="text-gray" href="/index">
+    <a id="header-logo" class="text-gray" href="/">
       <img src="assets/images/logo/logo.svg" alt="">
     </a>
     <nav id="nav" class="absolute flex items-center justify-end -z-1 top-0 left-0 h-screen w-full bg-gray pt-16 pr-16 transform -translate-y-full md:-translate-y-0 md:bg-white md:relative md:h-auto md:p-0 md:justify-center md:z-0">
@@ -20,22 +20,22 @@
         <img src="assets/images/logo/logo-nav-pink.svg" alt="">
       </div>
       <ul class="text-right text-white md:flex md:text-gray md:text-center">
-        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/index">Home</a></li>
+        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/">Home</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/about">About</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/node">Try</a></li>
-        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium font-bold text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/blog">Blog</a></li>
+        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium font-bold text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://vac.dev/research-log/">Blog</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Support</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
       </ul>
     </nav>
     <div id="social-box" class="hidden md:flex">
-      <a class="text-gray mr-6 hover:text-blue" href="">
+      <a class="text-gray mr-6 hover:text-blue" href="https://discord.gg/ev9GQGJ9Dg">
         <img src="./assets/images/social/discord-dark.svg" alt="discord">
       </a>
-      <a class="text-gray mr-6 hover:text-blue" href="">
+      <a class="text-gray mr-6 hover:text-blue" href="https://twitter.com/vacp2p">
         <img src="./assets/images/social/twitter-dark.svg" alt="twitter">
       </a>
-      <a class="text-gray hover:text-blue" href="">
+      <a class="text-gray hover:text-blue" href="https://github.com/vacp2p/">
         <img src="./assets/images/social/github-dark.svg" alt="github">
       </a>
     </div>
@@ -178,7 +178,7 @@
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">FAQ</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/node">Run a node</a></li>
-          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/blog">Blog</a></li>
+          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://vac.dev/research-log/">Blog</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://forum.vac.dev/">Forum</a></li>
           <li><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://jobs.status.im/">Careers</a></li>
         </ul>

--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,7 @@
 	<body class="font-body overflow-x-hidden">
 		<header class="fixed inset-x-0 z-50 bg-white">
 			<div class="h-18 max-w-screen-xl flex justify-between items-center mx-auto px-6 py-4  md:h-26 md:py-8 xl:px-0">
-				<a id="header-logo" class="text-gray" href="/index">
+				<a id="header-logo" class="text-gray" href="/">
 					<img src="assets/images/logo/logo.svg" alt="">
 				</a>
 				<nav id="nav" class="absolute flex items-center justify-end -z-1 top-0 left-0 h-screen w-full bg-gray pt-16 pr-16 transform -translate-y-full md:-translate-y-0 md:bg-white md:relative md:h-auto md:p-0 md:justify-center md:z-0">
@@ -20,22 +20,22 @@
 						<img src="./assets/images/logo/logo-nav-pink.svg" alt="Waku">
 					</div>
 					<ul class="text-right text-white md:flex md:text-gray md:text-center">
-						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium font-bold text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/index">Home</a></li>
+						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium font-bold text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/">Home</a></li>
 						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/about">About</a></li>
 						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/node">Try</a></li>
-						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/blog">Blog</a></li>
+						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://vac.dev/research-log/">Blog</a></li>
 						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Support</a></li>
 						<li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
 					</ul>
 				</nav>
 				<div id="social-box" class="hidden md:flex">
-					<a class="text-gray mr-6 hover:text-blue" href="">
+					<a class="text-gray mr-6 hover:text-blue" href="https://discord.gg/ev9GQGJ9Dg">
 						<img src="./assets/images/social/discord-dark.svg" alt="discord">
 					</a>
-					<a class="text-gray mr-6 hover:text-blue" href="">
+					<a class="text-gray mr-6 hover:text-blue" href="https://twitter.com/vacp2p">
 						<img src="./assets/images/social/twitter-dark.svg" alt="twitter">
 					</a>
-					<a class="text-gray hover:text-blue" href="">
+					<a class="text-gray hover:text-blue" href="https://github.com/vacp2p/">
 						<img src="./assets/images/social/github-dark.svg" alt="github">
 					</a>
 				</div>
@@ -148,7 +148,7 @@
 						<p class="text-sm leading-6">A nim implementation of the Waku v2 protocol. Reference client and flagship
 							implementation.</p>
 						<a class="inline-block text-sm italic underline pl-3 mt-6 bg-link-arrow-white bg-left bg-no-repeat lg:no-underline hover:underline"
-							 href="">Install nim-waku</a>
+							 href="https://github.com/status-im/nim-waku/">Install nim-waku</a>
 					</div>
 				</div>
 				<div class="bg-gray text-white py-12 px-8">
@@ -157,7 +157,7 @@
 						<p class="text-sm leading-6">A JS implementation to reach browser environments and optimized for interacting
 							with Dapps.</p>
 						<a class="inline-block text-sm underline italic pl-3 mt-6 bg-link-arrow-white bg-left bg-no-repeat lg:no-underline hover:underline"
-							 href="">Install js-waku</a>
+							 href="https://github.com/status-im/js-waku">Install js-waku</a>
 					</div>
 				</div>
 				<div class="bg-blue text-white py-12 px-8">
@@ -166,7 +166,7 @@
 						<p class="text-sm leading-6">Subset of Waku v2 implemented to facilitate integration with Status mobile
 							app.</p>
 						<a class="inline-block text-sm underline italic pl-3 mt-6 bg-link-arrow-white bg-left bg-no-repeat lg:no-underline hover:underline"
-							 href="">Install go-waku</a>
+							 href="https://github.com/status-im/go-waku">Install go-waku</a>
 					</div>
 				</div>
 				<div class="bg-pink text-gray py-12 px-8">
@@ -175,7 +175,7 @@
 						<p class="text-sm leading-6">Remove centralized choke points from your communication and help decentralize
 							the Waku Network by running your own node.</p>
 						<a class="inline-block text-sm text-blue underline italic pl-3 mt-6 bg-link-arrow-blue bg-left bg-no-repeat lg:no-underline hover:underline"
-							 href="">Node Quick Start Guide</a>
+							 href="/node">Node Quick Start Guide</a>
 					</div>
 				</div>
 			</section>
@@ -368,7 +368,7 @@
 						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">FAQ</a></li>
 						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
 						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/node">Run a node</a></li>
-						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/blog">Blog</a></li>
+						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://vac.dev/research-log/">Blog</a></li>
 						<li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://forum.vac.dev/">Forum</a></li>
 						<li><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://jobs.status.im/">Careers</a></li>
 					</ul>

--- a/src/node.html
+++ b/src/node.html
@@ -13,7 +13,7 @@
 
 <header class="fixed inset-x-0 z-50 bg-white">
   <div class="h-18 max-w-screen-xl flex justify-between items-center mx-auto px-6 py-4  md:h-26 md:py-8 xl:px-0">
-    <a id="header-logo" class="text-gray" href="/index">
+    <a id="header-logo" class="text-gray" href="/">
       <img src="assets/images/logo/logo.svg" alt="">
     </a>
     <nav id="nav" class="absolute flex items-center justify-end -z-1 top-0 left-0 h-screen w-full bg-gray pt-16 pr-16 transform -translate-y-full md:-translate-y-0 md:bg-white md:relative md:h-auto md:p-0 md:justify-center md:z-0">
@@ -23,22 +23,22 @@
         </svg>
       </div>
       <ul class="text-right text-white md:flex md:text-gray md:text-center">
-        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/index">Home</a></li>
+        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/">Home</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/about">About</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium font-bold text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/node">Try</a></li>
-        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="/blog">Blog</a></li>
+        <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://vac.dev/research-log/">Blog</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="">Support</a></li>
         <li class="mb-8 md:w-16 md:mb-0 lg:w-24"><a class="font-medium text-2xl md:text-xs md:hover:underline md:hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
       </ul>
     </nav>
     <div id="social-box" class="hidden md:flex">
-      <a class="text-gray mr-6 hover:text-blue" href="">
+      <a class="text-gray mr-6 hover:text-blue" href="https://discord.gg/ev9GQGJ9Dg">
         <img src="./assets/images/social/discord-dark.svg" alt="discord">
       </a>
-      <a class="text-gray mr-6 hover:text-blue" href="">
+      <a class="text-gray mr-6 hover:text-blue" href="https://twitter.com/vacp2p">
         <img src="./assets/images/social/twitter-dark.svg" alt="twitter">
       </a>
-      <a class="text-gray hover:text-blue" href="">
+      <a class="text-gray hover:text-blue" href="https://github.com/vacp2p/">
         <img src="./assets/images/social/github-dark.svg" alt="github">
       </a>
     </div>
@@ -277,7 +277,7 @@
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="">FAQ</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://rfc.vac.dev/spec/10/">Specs</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/node">Run a node</a></li>
-          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="/blog">Blog</a></li>
+          <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://vac.dev/research-log/">Blog</a></li>
           <li class="mb-4"><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://forum.vac.dev/">Forum</a></li>
           <li><a class="text-sm leading-6 hover:underline hover:text-blue" href="https://jobs.status.im/">Careers</a></li>
         </ul>


### PR DESCRIPTION
Updated broken links based on https://github.com/vacp2p/wakunetwork.com/issues/5

Also, I found that all the blog post links at https://wakunetwork.com/blog are broken but they are the same as https://vac.dev/research-log/, so used `https://vac.dev/research-log/` instead of `/blog` for footer and header.

What links do we need for the content below?
1. Top Navigation :  Support
2. Footer : FAQ
3. History : details 

If there are no appropriate links, we'd better remove them.
